### PR TITLE
Change .gitmodules to use a URL instead of path.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "srb2kart"]
 	path = srb2kart
-	url = git@github.com:formulabun/srb2kart.git
+	url = https://github.com/formulabun/srb2kart.git


### PR DESCRIPTION
This allows users to download the submodules from git command line.